### PR TITLE
calculateNextValue return key instead of object

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -90,7 +90,7 @@ export function calculateNextValue(func, value, props) {
   if (props.step) {
     return operations[func](value, props.step);
   } else if (!!Object.keys(props.marks).length && !!props.marks[keyToGet]) {
-    return props.marks[keyToGet];
+    return keyToGet;
   }
   return value;
 }


### PR DESCRIPTION
Currently, `util.calculateNextValue()` incorrectly returns mark object instead of value when steps are disabled (by passing `null` to `step` prop) and marks are used

The consequence of this is keyboard navigation will crash the slider due to unhandled errors that stem from unexpected value type.

# Steps to reproduce
1. Pass a marks object as prop to slider component
2. Pass ```step = {null}``` as prop to  slider component
3. Manipulate slider position using arrow keys